### PR TITLE
Fix compiler errors with gcc 11 on linux

### DIFF
--- a/ustring.h
+++ b/ustring.h
@@ -2,9 +2,11 @@
 
 #include <cctype>
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <atomic>
 #include <cassert>
+#include <limits>
 #include <vector>
 #include <span>
 #include <locale>
@@ -538,10 +540,15 @@ struct ustring::impl {
     };
 };
 
+namespace detail
+{
+    template <typename... Args>
+    constexpr bool dependent_false = false;
+}
 
 //////////////// Method implementations ////////////////
 
-template<character T> static constexpr ustring::encoding_t ustring::encoding_of()
+template<character T> constexpr ustring::encoding_t ustring::encoding_of()
 {
     if constexpr(is_same_v<T, char>)
         return narrow;
@@ -554,7 +561,8 @@ template<character T> static constexpr ustring::encoding_t ustring::encoding_of(
     else if constexpr(is_same_v<T, char32_t>)
         return utf32;
     else
-        static_assert(false, "This implementation has another std::character type not implemented by ustring");
+        static_assert(detail::dependent_false<T>,
+                      "This implementation has another std::character type not implemented by ustring");
 }
 
 template<> struct ustring::encoding_type_detail<ustring::narrow> {


### PR DESCRIPTION
Compiled on Arch Linux with gcc 11.

Clang 13.0 does not compile this code but that is out of scope for this PR.

Note that there are still warnings pertaining to the incorrect naming of UDLs which should be addressed; indeed clang issues a hard error for this.

Signed-off-by: David Brown <d.brown@bigdavedev.com>